### PR TITLE
fix(decoder): failed to decode image

### DIFF
--- a/src/qrcode/decoder/Reader.ts
+++ b/src/qrcode/decoder/Reader.ts
@@ -136,16 +136,18 @@ export class Decoder {
 
         const width: number = image.width;
         const height: number = image.height;
+        const actualWidth = Math.min(960, width);
+        const actualHeight = height * (actualWidth / width);
         const canvas: HTMLCanvasElement = document.createElement('canvas');
         const context: CanvasRenderingContext2D = canvas.getContext('2d');
 
-        canvas.width = width;
-        canvas.height = height;
+        canvas.width = actualWidth;
+        canvas.height = actualHeight;
 
-        context.drawImage(image, 0, 0);
+        context.drawImage(image, 0, 0, width, height, 0, 0, actualWidth, actualHeight);
 
-        const { data }: ImageData = context.getImageData(0, 0, width, height);
-        const result: DecoderResult = this.decode(data, width, height);
+        const imageData = context.getImageData(0, 0, actualWidth, actualHeight);
+        const result: DecoderResult = this.decode(imageData.data, imageData.width, imageData.height);
 
         if (result) {
           return resolve(result);


### PR DESCRIPTION
## [@nuintun+qrcode+3.0.1.patch](https://www.npmjs.com/package/patch-package)

```diff
diff --git a/node_modules/@nuintun/qrcode/esnext/qrcode/decoder/Reader.js b/node_modules/@nuintun/qrcode/esnext/qrcode/decoder/Reader.js
index 9ed2864..2f3a198 100644
--- a/node_modules/@nuintun/qrcode/esnext/qrcode/decoder/Reader.js
+++ b/node_modules/@nuintun/qrcode/esnext/qrcode/decoder/Reader.js
@@ -99,13 +99,15 @@ var Decoder = /*#__PURE__*/ (function () {
                 disposeImageEvents(image);
                 var width = image.width;
                 var height = image.height;
+                var actualWidth = Math.min(960, width);
+                var actualHeight = height * (actualWidth / width);
                 var canvas = document.createElement('canvas');
                 var context = canvas.getContext('2d');
-                canvas.width = width;
-                canvas.height = height;
-                context.drawImage(image, 0, 0);
-                var data = context.getImageData(0, 0, width, height).data;
-                var result = _this.decode(data, width, height);
+                canvas.width = actualWidth;
+                canvas.height = actualHeight;
+                context.drawImage(image, 0, 0, width, height, 0, 0, actualWidth, actualHeight);
+                var imageData = context.getImageData(0, 0, actualWidth, actualHeight);
+                var result = _this.decode(imageData.data, imageData.width, imageData.height);
                 if (result) {
                     return resolve(result);
                 }

```