### PR TITLE
Make sure to always return null on Decoder's `readVersion()`

### DIFF
--- a/examples/qrcode.js
+++ b/examples/qrcode.js
@@ -4518,11 +4518,12 @@
     return codewords;
   }
   function readVersion(matrix) {
+    var _a;
     var dimension = matrix.height;
     var provisionalVersion = Math.floor((dimension - 17) / 4);
     if (provisionalVersion <= 6) {
       // 6 and under dont have version info in the QR code
-      return VERSIONS[provisionalVersion - 1];
+      return (_a = VERSIONS[provisionalVersion - 1]) !== null && _a !== void 0 ? _a : null;
     }
     var topRightVersionBits = 0;
     for (var y = 5; y >= 0; y--) {

--- a/src/qrcode/decoder/decoder/index.ts
+++ b/src/qrcode/decoder/decoder/index.ts
@@ -162,7 +162,7 @@ function readVersion(matrix: BitMatrix): Version | null {
 
   if (provisionalVersion <= 6) {
     // 6 and under dont have version info in the QR code
-    return VERSIONS[provisionalVersion - 1];
+    return VERSIONS[provisionalVersion - 1] ?? null;
   }
 
   let topRightVersionBits = 0;


### PR DESCRIPTION
In some cases, the decoder would find a section that looks like a QR Code, but it's smaller than 21x21, causing the version number calculation in `readVersion()` to go below zero and making the function return undefined. Because down the line there is a check for `null`, but not `undefined`, this causes the decoder to crash on `buildFunctionPatternMask()`.
I found this to be more common on particularily grainy images like the ones from a notebook webcam.

The fix is a simple nullish coalescence to always return null and have the decoder correctly report that there is no valid QR Code in the region scanned. I also checked no other paths of this function could return anything other than a valid Version object or null.

Stacktrace:
```
qrcode.js:4459 Uncaught TypeError: Cannot read properties of undefined (reading 'versionNumber')
    at buildFunctionPatternMask (qrcode.js:4459:38)
    at readCodewords (qrcode.js:4485:31)
    at decodeMatrix (qrcode.js:4668:21)
    at decode (qrcode.js:4696:18)
    at scan (qrcode.js:4887:21)
    at Decoder.decode (qrcode.js:4945:20)
```
Note the library was transpiled in my case so line numbers are different.